### PR TITLE
Fix for docker-compose build

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - es_net
 
   backend:
-    build: /parec-backend/.
+    build: ./parec-backend/.
     container_name: backend
     networks:
       - backend_net
@@ -19,7 +19,7 @@ services:
       - es
 
   frontend:
-    build: /parec-frontend/.
+    build: ./parec-frontend/.
     container_name: frontend
     ports:
       - 80:80


### PR DESCRIPTION
Noticed that `docker-compose` was trying to interpret the two path specs as URLs instead. Adding the leading `./` fixes this.